### PR TITLE
Fix eslint on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node test/",
     "linters": "npm run js-lint",
-    "js-lint": "eslint './*.js' -c ./.eslintrc --quiet"
+    "js-lint": "eslint \"./*.js\" -c ./.eslintrc --quiet"
   },
   "repository": {
     "type": "git",

--- a/templates/package.json
+++ b/templates/package.json
@@ -7,7 +7,7 @@
     "test": "jest --watch",
     "test-ci": "jest --ci && npm run linters && npm run size && npm run audit",
     "size": "bundlesize",
-    "linters": "eslint './src/**/*.js'",
+    "linters": "eslint \"./src/**/*.js\"",
     "audit": "audit-ci --high",
     "release": "standard-version"
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

Windows doesn't play nice with eslint using single quotes.

## Solution Description

This is a general issue with the windows terminal but the fix is easy, simply replace single quotes with escaped double quotes.

## Side Effects, Risks, Impact

Needs to be tested on other OS's

**Aditional comments:**
